### PR TITLE
add `json_logger` decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,17 @@ logger.info(msg="what is my purpose?", meaning_of_life=42)
 ```
 {"logger": {"application": "my-custom-logger", "environment": "dev"}, "level": "info", "timestamp": "2020-11-03 18:31:07.757534", "message": "what is my purpose?", "extra": {"meaning_of_life": 42}}
 ```
+`datatoolz.logging.json_logger` is a decorator logger for outputting JSON-structured logs from a function
+```python
+from datatoolz.logging import json_logger
+
+@json_logger(msg="my-custom-log", duration=True, memory=True, my_value="my-value", output_length=lambda x: len(x))
+def my_func(x, y):
+    return x + y, x * y
+
+print(my_func(42, 2))
+```
+```
+{"logger": {"application": null, "environment": null}, "level": "info", "timestamp": "2021-03-24 18:10:47.054703", "message": "my-custom-log", "extra": {"function": "my_func", "memory": {"current": 432, "peak": 432}, "duration": 2.5980000000203063e-06, "my_value": "my-value", "output_length": 2}}
+(44, 84)
+```

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ requirements = ["s3fs==0.4.2", "pandas", "pyarrow"]
 
 setuptools.setup(
     name="data-toolz",
-    version="0.1.4",
+    version="0.1.5",
     author="Grzegorz Melniczak",
     author_email="mogadish@gmail.com",
     description="Data helper package",

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -46,3 +46,25 @@ class TestLogging(object):
         for k, v in params["logger-call"].items():
             if k != "msg":
                 assert log["extra"][k] == v
+
+    def test_logger_decorator(self, capsys):
+        import datatoolz.logging as logging
+
+        @logging.json_logger(
+            msg="my-message", static_value="my-value", length=lambda x: len(x)
+        )
+        def my_func(a, b):
+            return a + b, a * b
+
+        my_func(1, 2)
+
+        log, _ = capsys.readouterr()
+        log = json.loads(log)
+
+        assert log["message"] == "my-message"
+        assert log["level"] == "info"
+        assert log["extra"]["function"] == "my_func"
+        assert log["extra"]["duration"] >= 0
+        assert log["extra"]["memory"]["peak"] >= 0
+        assert log["extra"]["static_value"] == "my-value"
+        assert log["extra"]["length"] == 2


### PR DESCRIPTION
This MR will add `json_logger` decorator for measuring function execution (duration, memory, result summary, other custom metrics)