### PR TITLE
Adding `assume-chain` feature

### DIFF
--- a/datatoolz/filesystem.py
+++ b/datatoolz/filesystem.py
@@ -74,15 +74,19 @@ class FileSystem(AbstractFileSystem):
 
             credentials = assume_client.assume_role(
                 RoleArn=role,
-                RoleSessionName=f"data-toolz-filesystem-s3-{role}",
+                RoleSessionName="data-toolz-filesystem-s3",
                 DurationSeconds=3600,
             ).get("Credentials")
 
-            setattr(session, "_credentials", botocore.credentials.Credentials(
-                access_key=credentials["AccessKeyId"],
-                secret_key=credentials["SecretAccessKey"],
-                token=credentials["SessionToken"],
-            ))
+            setattr(
+                session,
+                "_credentials",
+                botocore.credentials.Credentials(
+                    access_key=credentials["AccessKeyId"],
+                    secret_key=credentials["SecretAccessKey"],
+                    token=credentials["SessionToken"],
+                ),
+            )
 
         del session
         return {

--- a/datatoolz/filesystem.py
+++ b/datatoolz/filesystem.py
@@ -13,6 +13,14 @@ class FileSystem(AbstractFileSystem):
     """Wrapper for easier initialization of various file-system classes"""
 
     def __init__(self, name="local", assumed_role=None, endpoint_url=None):
+        """
+        FileSystem initializer
+        :param name: str, filesystem type, supported values [local|s3]
+        :param assumed_role: optional str|list,
+            permission assume chain - relevant for [s3]
+        :param endpoint_url: optional str, override storage service url
+        """
+
         super().__init__()
         self.name = name
         self.assume_client = None

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -38,14 +38,25 @@ class TestFileSystem(unittest.TestCase):
     def test_s3_with_assume(self):
         from datatoolz.filesystem import FileSystem
 
-        fs = FileSystem(name="s3", assumed_role="arn:some:random:long:enough:string")
+        assume_chains = [
+            "arn:some:random:long:enough:string",
+            ["arn:some:random:long:enough:string"],
+            [
+                "arn:some:random:long:enough:string",
+                "arn:other:random:long:enough:string",
+            ],
+        ]
 
-        file_name = os.path.join(self.bucket_name, "with-assume", "test.txt")
-        with fs.open(file_name, mode="wt") as fo:
-            fo.write("test")
+        for roles in assume_chains:
 
-        result = list(fs.find(path=os.path.join(self.bucket_name, "with-assume")))
-        assert [file_name] == result
+            fs = FileSystem(name="s3", assumed_role=roles)
+
+            file_name = os.path.join(self.bucket_name, "with-assume", "test.txt")
+            with fs.open(file_name, mode="wt") as fo:
+                fo.write("test")
+
+            result = list(fs.find(path=os.path.join(self.bucket_name, "with-assume")))
+            assert [file_name] == result
 
     def test_filesystem_basics(self):
         from datatoolz.filesystem import FileSystem


### PR DESCRIPTION
This feature will allow to create `s3` FileSystem using multiple consecutive `assume-role` actions.
```python
# {current-role} --assume--> {role-1} --assume--> {role-2}
fs = FileSystem("s3", assumed_role=["arn:role-1", "arn:role-2"])
```